### PR TITLE
Thor

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,6 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
+| [Thor](http://whatisthor.com/) | `export THOR_SHELL=Basic` ([Docs](http://www.rubydoc.info/github/wycats/thor/Thor%2FBase.shell)) |
 {: rules="groups"}
 
 ## Software with no mechanism to disable color


### PR DESCRIPTION
Thor is used by most Ruby command-line tools. It does not understand
that we don't want color, but it does understand when not to show color.
The `THOR_SHELL` environment variable controls whether it should write
to a "Basic" or "Color" object.