### PR TITLE
RSpec

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
-| [RSpec](http://rspec.info/) | `rspec --no-color` | Can also be set in the `SPEC_OPTS` environment variable or the `.rspec` configuration file.
+| [RSpec](http://rspec.info/) | `export SPEC_OPTS=--no-color` |
 {: rules="groups"}
 
 ## Software with no mechanism to disable color

--- a/index.md
+++ b/index.md
@@ -47,6 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
+| [RSpec](http://rspec.info/) | `rspec --no-color` | Can also be set in the `SPEC_OPTS` environment variable or the `.rspec` configuration file.
 {: rules="groups"}
 
 ## Software with no mechanism to disable color


### PR DESCRIPTION
The rspec command-line runner understands a `--no-color` flag. This is
not documented per se but it is in the output of `rspec --help`.

It can be passed as a command-line flag, through the `SPEC_OPTS`
environment variable, or in a `.rspec` configuration. Note that a
`~/.rspec` is read first, then `./.rspec`, then `SPEC_OPT`, then
command-line args.