### PR TITLE
Ruby compilation

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,6 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
+| [Ruby](https://www.ruby-lang.org/) | `export TEST_COLORS=pass=0:fail=0` |
 {: rules="groups"}
 
 ## Software with no mechanism to disable color


### PR DESCRIPTION
When compiling Ruby itself, it has started showing colored output on the
terminal. We can silence this via the `TEST_COLORS` environmnt variable.

This was changed in this commit:
https://github.com/ruby/ruby/commit/5a599dde0c43b62ff32c8a0c36a05a758a309818