### PR TITLE
The Silver Searcher (ag)

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,6 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
+| [The Silver Searcher](https://geoff.greer.fm/ag/) | `ag --nocolor` |
 {: rules="groups"}
 
 ## Software with no mechanism to disable color


### PR DESCRIPTION
Not a ton of documentation around this, but this is in the `ag --help`
output.

---

Note that I have this:

```
alias ag='ag --color-line-number=0 --color-match="37;1" --color-path="37;4"'
```

Because I like the highlights but not the colors.