### PR TITLE
util-linux

### DIFF
--- a/index.md
+++ b/index.md
@@ -47,6 +47,7 @@ and submit a pull request.
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
+| util-linux | `touch /etc/terminal-colors.d/disable` ([Docs](http://man7.org/linux/man-pages/man5/terminal-colors.d.5.html)) |
 {: rules="groups"}
 
 ## Software with no mechanism to disable color


### PR DESCRIPTION
The util-linux collection of tools checks a centralized file for color
information, as described in [the author's
blog](http://karelzak.blogspot.com/2014/04/terminal-colorsd.html).

This affects many utilities on GNU/Linux such as dmesg, cfdisk, cal,
fdisk, and sfdisk.