### PR TITLE
Fix ruby test

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,7 +60,7 @@ and submit a pull request.
 | [Midnight Commander](https://midnight-commander.org/) | `mc --nocolor` |
 | [Ripgrep](https://github.com/BurntSushi/ripgrep) | `rg --color=never` |
 | [RSpec](http://rspec.info/) | `export SPEC_OPTS=--no-color` |
-| [Ruby](https://www.ruby-lang.org/) | `export TEST_COLORS=pass=0:fail=0` |
+| [Ruby](https://www.ruby-lang.org/) | `export RUBY_TESTOPTS=--color=never` |
 | [The Silver Searcher](https://geoff.greer.fm/ag/) | `ag --nocolor` ([Pending PR](https://github.com/ggreer/the_silver_searcher/pull/1207)) |
 | [Thor](http://whatisthor.com/) | `export THOR_SHELL=Basic` ([Docs](http://www.rubydoc.info/github/wycats/thor/Thor%2FBase.shell)) |
 | [util-linux](https://github.com/karelzak/util-linux) | `touch /etc/terminal-colors.d/disable` ([Docs](http://man7.org/linux/man-pages/man5/terminal-colors.d.5.html)) |


### PR DESCRIPTION
setting `TEST_COLORS=pass=0:fail=0` makes output *default* color, not setting any colors.
`--color=never` option disable color, and `TESTOPTS` in `make` command line will be passed to test process.
If you prefer to disable it without the command line, set `RUBY_TESTOPTS` environment variable.