### PR TITLE
index: Add KBSecret

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,6 +40,7 @@ and submit a pull request.
 | [crayon](https://github.com/r-lib/crayon) | R package for colored terminal output | [2018-02-08](https://github.com/r-lib/crayon/commit/700800135d04408bf1c99426b3fec9a4073b8a97) |
 | [ffind](https://github.com/josephscade/ffind) | Rust utility to find files and folders | [2018-03-24](https://github.com/josephscade/ffind/commit/fec4aa6101f2b3d6d5b06df640e299d0b1fbb190) |
 | [Homebrew](https://brew.sh/) | Package manager for macOS | [2018-02-12](https://github.com/Homebrew/brew/commit/b3f0e571f4cdcc29dd6982b863fdcd7de5e6febf) |
+| [KBSecret](https://kbsecret.github.io/) | Secret manager backed by Keybase and KBFS | [1.4.0](https://github.com/kbsecret/kbsecret/releases/tag/1.4.0) |
 | [LogColor](https://github.com/induane/logcolor) | Python library for coloring output in log messages | [2018-01-24](https://github.com/induane/logcolor/commit/0092b0af2a1506eee2b0ca028b1cf51f78fc91fa) |
 | [lr](https://github.com/chneukirchen/lr) | File list generator | [2018-01-29](https://github.com/chneukirchen/lr/commit/8f0ac7c8abb4e0830d6cf72bbbd5f38c44b4266d) |
 | [mblaze](https://github.com/chneukirchen/mblaze) | Unix utilities to deal with Maildir | [2018-01-29](https://github.com/chneukirchen/mblaze/commit/4014f03afe6d624ba1c6bdde6551b4996ba31fe5) |


### PR DESCRIPTION
I saw `NO_COLOR` in `brew`, and thought it was a neat idea. Thanks for making the effort to standardize this sort of behavior!

KBSecret is just a secrets manager (that I maintain) that uses Keybase and KBFS for encryption and storage. I linked to version 1.4.0 in the `index.md` (the first to support `NO_COLOR`), but I can change that to the commit if you'd like.