### PR TITLE
index: Add twa

### DIFF
--- a/index.md
+++ b/index.md
@@ -56,6 +56,7 @@ and submit a pull request.
 | [Snow](https://github.com/mortie/snow) | Testing library for C | [2018-01-24](https://github.com/mortie/snow/commit/aadbbd375e03ec6000e23d817d2bd722b417296f) |
 | [taoup](http://github.com/globalcitizen/taoup) | Fortune implementation | [2018-09-10](https://github.com/globalcitizen/taoup/commit/fb2dc7768a2dc9b74816ce5126e40b93338291f7) |
 | [txtnish](https://github.com/mdom/txtnish) | Twtxt microblogging client | [2018-08-31](https://github.com/mdom/txtnish/commit/257d312ac282ab99e8357e31f6c282b881fbb171) |
+| [twa](https://github.com/trailofbits/twa) | A tiny web auditor with strong opinions | [1.1.0](https://github.com/trailofbits/twa/releases/tag/1.1.0) |
 {: rules="groups"}
 
 ## Disabling color in software not supporting `NO_COLOR`


### PR DESCRIPTION
This adds [twa](github.com/trailofbits/twa) to the list of `NO_COLOR` compatible programs.

Please let me know if anything needs to be fixed/corrected!