### PR TITLE
Add alogview

### DIFF
--- a/index.md
+++ b/index.md
@@ -37,6 +37,7 @@ and submit a pull request.
 
 | Software | Description | Version/Date Supported |
 |:-|:-|:-|
+| [alogview](https://github.com/flimberger/alogview) | Android logcat Filter | [2018-10-31](https://github.com/flimberger/alogview/commit/785e5608711d92a1c41733f9ecfa3ed2d335a940) |
 | [Bikeshed](https://github.com/tabatkins/bikeshed) | Spec/Document Processor | [2018-07-27](https://github.com/tabatkins/bikeshed/commit/04ea123d607a8d4bed692ad73dda1cb343bb5bbe) |
 | [Bloop](https://github.com/scalacenter/bloop) | Compilation/test server for Scala and Java | [2018-07-02](https://github.com/scalacenter/bloop/pull/555/commits/ff6f17a0155633f86440e10d7889f077e7fbc91c) |
 | [crayon](https://github.com/r-lib/crayon) | R package for colored terminal output | [2018-02-08](https://github.com/r-lib/crayon/commit/700800135d04408bf1c99426b3fec9a4073b8a97) |


### PR DESCRIPTION
[Alogview](https://github.com/flimberger/alogview) is a helper for
`adb logcat`, which filters the log message by their process ID instead
of their log tag, so all messages from a specific application package
are logged regardless of their tag.