### PR TITLE
CSS: Add alpha-channels to background-colors.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
 		}
 
 		th {
-			background-color: #ddd;
+			background-color: #ddd2;
 		}
 
 		th, td {
@@ -51,7 +51,7 @@
 		}
 
 		td code, p code {
-			background-color: #f5f5f5;
+			background-color: #f5f5f520;
 			padding: 3px;
 		}
 


### PR DESCRIPTION
There are no site-wide background-color and text-color defined. Using background-color for individual elements makes parts of the website unreadable for users with dark themes.

Before:

![screenshot_2019-11-17T13-52-15](https://user-images.githubusercontent.com/3681516/69007772-7b56d080-0942-11ea-954c-89ca42f36c2a.png)

After:

![screenshot_2019-11-17T13-51-22](https://user-images.githubusercontent.com/3681516/69007773-80b41b00-0942-11ea-86d6-75932d93da7f.png)
