### PR TITLE
Add pytest 6.0.0

### DIFF
--- a/index.md
+++ b/index.md
@@ -101,6 +101,7 @@ color via `NO_COLOR`.
 | [procs](https://github.com/c-blake/procs) | Process and system query and formatting | [2019-11-18](https://github.com/c-blake/procs/commit/7d19fc184f8c29481dd5a4c4d5d26c671c2c0a4c) |
 | [pulumi](https://pulumi.io/) | Programming-language-based IaC framework | [0.14.3](https://github.com/pulumi/pulumi/pull/1594) |
 | [PyDERASN](http://pyderasn.cypherpunks.ru/) | Python ASN.1 DER library | [2018-02-14](https://git.cypherpunks.ru/cgit.cgi/pyderasn.git/commit/?id=54876436a23f14951f2e6353e9072c9a098b35b4) |
+| [pytest](https://pytest.org) | Python testing framework | [6.0.0](https://docs.pytest.org/en/stable/changelog.html#pytest-6-0-0-2020-07-28) |
 | [rsmodules](https://github.com/fretn/rsmodules) | Manage one's environment by the use of modulefiles | [2018-10-09](https://github.com/fretn/rsmodules/commit/87a45f96a9bd45b86300a6027bb29855778d4f5e) |
 | [smenu](https://github.com/p-gen/smenu) | Terminal selection filter | [2018-02-05](https://github.com/p-gen/smenu/commit/70d3ee5a328230dff3b744b2f0ca7ef20ecb530e) |
 | [Snow](https://github.com/mortie/snow) | Testing library for C | [2018-01-24](https://github.com/mortie/snow/commit/aadbbd375e03ec6000e23d817d2bd722b417296f) |


### PR DESCRIPTION
The Python test framework pytest added support for `NO_COLOR` (and `FORCE_COLOR`) in 6.0.0:

* https://docs.pytest.org/en/stable/changelog.html#pytest-6-0-0-2020-07-28

See also:

* Issue https://github.com/pytest-dev/pytest/issues/7464
* PR https://github.com/pytest-dev/pytest/pull/7466
