### PR TITLE
index: Fix typo in GCC command line option

### DIFF
--- a/index.md
+++ b/index.md
@@ -143,7 +143,7 @@ color via `NO_COLOR`.
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
 | [FFmpeg](https://ffmpeg.org/) | `export AV_LOG_FORCE_NOCOLOR=true` |
 | [fzf](https://github.com/junegunn/fzf) | `fzf --color=bw` or `export FZF_DEFAULT_OPTS=--color=bw` ([Docs](https://github.com/junegunn/fzf/wiki/Color-schemes)) |
-| [GCC](https://gcc.gnu.org/) | `export GCC_COLORS=` or `-fno-color-diagnostics` ([Docs](https://gcc.gnu.org/onlinedocs/gcc-7.3.0/gcc/Diagnostic-Message-Formatting-Options.html)) |
+| [GCC](https://gcc.gnu.org/) | `export GCC_COLORS=` or `-fno-diagnostics-color` ([Docs](https://gcc.gnu.org/onlinedocs/gcc-7.3.0/gcc/Diagnostic-Message-Formatting-Options.html)) |
 | [Git](https://git-scm.com/) | `git config --global color.ui false` ([Docs](https://git-scm.com/docs/git-config#git-config-colorui))|
 | [GStreamer](https://gstreamer.freedesktop.org/) | `export GST_DEBUG_NO_COLOR=true` or `--gst-debug-no-color` ([Docs](https://developer.gnome.org/gstreamer/stable/gst-running.html)) |
 | [Lynx](http://lynx.browser.org/) | `lynx -nocolor` (or `show_color=never` in `.lynxrc`) |


### PR DESCRIPTION
Clang's `-fno-color-diagnostics` does not work with GCC:
```
$ gcc -fno-color-diagnostics
gcc: error: unrecognized command line option ‘-fno-color-diagnostics’; did you mean ‘-fno-cprop-registers’?
```

The linked docs mention `-fno-diagnostics-color` and `-fdiagnostics-color=never` as ways to disable color.  Keeping it simple by only listing the first one.