### PR TITLE
Add colors-option

### DIFF
--- a/index.md
+++ b/index.md
@@ -43,6 +43,7 @@ color via `NO_COLOR`.
 | [cli-color](https://github.com/medikoo/cli-color) | NPM package for colors and formatting | [2019-10-09 / 2.0.0](https://github.com/medikoo/cli-color/releases/tag/v2.0.0) |
 | [ColorDebug](https://github.com/roboticslab-uc3m/color-debug) | Colorful command line output C/C++ macros | [2019-02-09](https://github.com/roboticslab-uc3m/color-debug/commit/2e2a5bf5a202228985612008967fb63ba8be53d8) |
 | [colored](https://github.com/mackwic/colored) | Rust crate for coloring terminal output | [2019-01-05 / 1.7.0](https://github.com/mackwic/colored/blob/master/CHANGELOG.md#170-january-2019) |
+| [colors-option](https://github.com/ehmicky/colors-option) | NPM package for colors and formatting based on chalk | [2021-03-02 / 1.0.0](https://github.com/ehmicky/colors-option/blob/master/CHANGELOG.md#100) |
 | [crayon](https://github.com/r-lib/crayon) | R package for colored terminal output | [2018-02-08](https://github.com/r-lib/crayon/commit/700800135d04408bf1c99426b3fec9a4073b8a97) |
 | [Dye](https://github.com/dduan/Dye) | Cross-platform terminal styling for Swift command-line interface | [2020-06-01 / 0.0.1](https://github.com/dduan/Dye/releases/tag/0.0.1) |
 | [Gapotchenko. FX.Console](https://github.com/gapotchenko/Gapotchenko.FX/tree/master/Source/Gapotchenko.FX.Console) | Virtual terminal functionality, console traits, and useful primitives for .NET console apps | [2020-01-15 / 2020.1.15](https://github.com/gapotchenko/Gapotchenko.FX/releases/tag/v2020.1.15) |


### PR DESCRIPTION
[`colors-option`](https://github.com/ehmicky/colors-option) is a thin wrapper around `chalk` which adds a `colors` boolean option and support for the `NO_COLOR` environment variable.

[`chalk`](https://github.com/chalk/chalk) is based on [`supports-color`](https://github.com/chalk/supports-color) which chose [not to support `NO_COLOR`](https://github.com/chalk/supports-color/issues/74). `chalk` was initially added in https://github.com/jcs/no_color/pull/99 but later removed in https://github.com/jcs/no_color/commit/98857d029b4952ed8266f5918c7881b73a93ce4b