### PR TITLE
Add Aurornis

### DIFF
--- a/index.md
+++ b/index.md
@@ -102,6 +102,7 @@ color via `NO_COLOR`.
 | [Ansible](https://github.com/ansible/ansible) | IT automation system | [2021-04-26 / 2.11.0](https://github.com/ansible/ansible/blob/stable-2.11/changelogs/CHANGELOG-v2.11.rst#v2-11-0) |
 | [Archey 4](https://github.com/HorlogeSkynet/archey4) | Python system information tool | [2020-09-26 / 4.8.0](https://github.com/HorlogeSkynet/archey4/releases/tag/v4.8.0) |
 | [Arduino CLI](https://github.com/arduino/arduino-cli) | Arduino command line tool  | [2021-09-02 / 0.19.0](https://github.com/arduino/arduino-cli/releases/tag/0.19.0) |
+| [Aurornis](https://github.com/Deuchnord/Aurornis) | A library to simplify command line programs testing | [2021-11-16 / 1.2.0](https://github.com/Deuchnord/Aurornis/releases/tag/v1.2.0) |
 | [Bashly](https://bashly.dannyb.co/) | Bash command line framework and CLI generator  | [2021-10-26 / 0.6.9](https://github.com/DannyBen/bashly/releases/tag/v0.6.9) |
 | [bat](https://github.com/sharkdp/bat) | A cat(1) clone with syntax highlighting and Git integration | [2020-10-02 / 0.16.0](https://github.com/sharkdp/bat/releases/tag/v0.16.0) |
 | [beets](https://github.com/beetbox/beets) | Music library manager and MusicBrainz tagger | [2019-05-30 / 1.4.9](https://github.com/beetbox/beets/releases/tag/v1.4.9) |


### PR DESCRIPTION
Proposing to add [Aurornis](https://github.com/Deuchnord/Aurornis), a small library to help testing command line programs.

Note: the library itself does not generate any string to output, but provides an option, `remove_colors` that, when set to `true`, sets `NO_COLOR` environment variable to inform the program to test we don't want colors.
Not totally sure Aurornis really fits the requirements to appear here, so feel free to close this PR if it does not.