### PR TITLE
Add kubedoc shell script to the list

### DIFF
--- a/index.md
+++ b/index.md
@@ -188,7 +188,7 @@ color via `NO_COLOR`.
 | [KBSecret](https://kbsecret.github.io/) | Secret manager backed by Keybase and KBFS | [2018-04-13 / 1.4.0](https://github.com/kbsecret/kbsecret/commit/d5296054d979a1b1ce07c1be78d56d3d29b62384) |
 | [kitten](https://github.com/hoffa/kitten) | Tiny multi-server automation tool | [2018-06-06 / 0.2.14](https://github.com/hoffa/kitten/commit/88cb015f4ae021a1c00bfc4dc9506a8e14e51bb4) |
 | [konch](https://github.com/sloria/konch) | Python shell/REPL configuration tool | [2019-01-19 / 4.0.0](https://github.com/sloria/konch/blob/master/CHANGELOG.rst#400-2019-01-19) |
-| [kubedoc](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) | Shell script to browse [K8s](https://kubernetes.io) API resources (uses [smenu](https://github.com/p-gen/smenu)) | [2022-08-23 / none](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) |
+| [kubedoc](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) | Shell script to browse [K8s](https://kubernetes.io) API resources (uses [smenu](https://github.com/p-gen/smenu)) | [2022-08-23](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) |
 | [lbt](https://gitlab.com/gardenappl/lbt) | Friendly tools for interacting with the LBRY network | [2022-03-31 / 2.1.2](https://gitlab.com/gardenappl/lbt/-/releases/v2.1.2)
 | [lc](https://github.com/c-blake/lc) | Multi-dimensional, abbreviating ls/file lister in Nim | [2019-11-18](https://github.com/c-blake/lc/commit/3f69e692db45c63320c3cbd2d3910208437687f9) |
 | [Lintian](https://lintian.debian.org) | Friendly packaging advice for Debian contributors | [2021-12-12 / 2.114.87](https://salsa.debian.org/lintian/lintian/-/commit/275a48e628120100a38cbcd5a4f7f5b70c5ab47d) |

--- a/index.md
+++ b/index.md
@@ -188,6 +188,7 @@ color via `NO_COLOR`.
 | [KBSecret](https://kbsecret.github.io/) | Secret manager backed by Keybase and KBFS | [2018-04-13 / 1.4.0](https://github.com/kbsecret/kbsecret/commit/d5296054d979a1b1ce07c1be78d56d3d29b62384) |
 | [kitten](https://github.com/hoffa/kitten) | Tiny multi-server automation tool | [2018-06-06 / 0.2.14](https://github.com/hoffa/kitten/commit/88cb015f4ae021a1c00bfc4dc9506a8e14e51bb4) |
 | [konch](https://github.com/sloria/konch) | Python shell/REPL configuration tool | [2019-01-19 / 4.0.0](https://github.com/sloria/konch/blob/master/CHANGELOG.rst#400-2019-01-19) |
+| [kubedoc](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) | Shell script to browse [K8s](https://kubernetes.io) API resources (uses [smenu](https://github.com/p-gen/smenu)) | [2022-08-23 / none](https://gist.github.com/mjf/bd03c62115a5c46b50851173741fb84b) |
 | [lbt](https://gitlab.com/gardenappl/lbt) | Friendly tools for interacting with the LBRY network | [2022-03-31 / 2.1.2](https://gitlab.com/gardenappl/lbt/-/releases/v2.1.2)
 | [lc](https://github.com/c-blake/lc) | Multi-dimensional, abbreviating ls/file lister in Nim | [2019-11-18](https://github.com/c-blake/lc/commit/3f69e692db45c63320c3cbd2d3910208437687f9) |
 | [Lintian](https://lintian.debian.org) | Friendly packaging advice for Debian contributors | [2021-12-12 / 2.114.87](https://salsa.debian.org/lintian/lintian/-/commit/275a48e628120100a38cbcd5a4f7f5b70c5ab47d) |


### PR DESCRIPTION
Without `NO_COLOR` environment variable set.
![kubedoc](https://user-images.githubusercontent.com/54104/186100807-2ff0d0f0-c030-46b0-a918-644530164a81.png)

**With** `NO_COLOR` environment variable set.
![kubedoc-no_color](https://user-images.githubusercontent.com/54104/186101559-ca4e975b-be5f-4c6f-bd43-3f957099d350.png)
And without colors.