### PR TITLE
Add LicensePlist

### DIFF
--- a/index.md
+++ b/index.md
@@ -192,6 +192,7 @@ color via `NO_COLOR`.
 | [konch](https://github.com/sloria/konch) | Python shell/REPL configuration tool | [2019-01-19 / 4.0.0](https://github.com/sloria/konch/blob/master/CHANGELOG.rst#400-2019-01-19) |
 | [lbt](https://gitlab.com/gardenappl/lbt) | Friendly tools for interacting with the LBRY network | [2022-03-31 / 2.1.2](https://gitlab.com/gardenappl/lbt/-/releases/v2.1.2)
 | [lc](https://github.com/c-blake/lc) | Multi-dimensional, abbreviating ls/file lister in Nim | [2019-11-18](https://github.com/c-blake/lc/commit/3f69e692db45c63320c3cbd2d3910208437687f9) |
+| [LicensePlist](https://github.com/mono0926/LicensePlist) | License list generator for Apple developer | [3.23.3](https://github.com/mono0926/LicensePlist/releases/tag/3.23.3) |
 | [Lintian](https://lintian.debian.org) | Friendly packaging advice for Debian contributors | [2021-12-12 / 2.114.87](https://salsa.debian.org/lintian/lintian/-/commit/275a48e628120100a38cbcd5a4f7f5b70c5ab47d) |
 | [lr](https://github.com/chneukirchen/lr) | File list generator | [2018-01-29](https://github.com/chneukirchen/lr/commit/8f0ac7c8abb4e0830d6cf72bbbd5f38c44b4266d) |
 | [lsd](https://github.com/Peltoche/lsd) | The next gen ls command | [2022-01-16 / 0.21.0](https://github.com/Peltoche/lsd/releases/tag/0.21.0) |


### PR DESCRIPTION
My adorable pull request supporting the `NO_COLOR` environment variable (alongside "--no-color" and `--color` command options) for [LicensePlist](https://github.com/mono0926/LicensePlist) has just been merged and released today.

Thanx