### PR TITLE
GitHub CLI disabling prompts turns off all ANSI prompting

### DIFF
--- a/index.md
+++ b/index.md
@@ -263,6 +263,7 @@ color via `NO_COLOR`.
 | [fzf](https://github.com/junegunn/fzf) | `fzf --color=bw` or `export FZF_DEFAULT_OPTS=--color=bw` ([Docs](https://github.com/junegunn/fzf/wiki/Color-schemes)) |
 | [GCC](https://gcc.gnu.org/) | `export GCC_COLORS=` or `-fno-diagnostics-color` ([Docs](https://gcc.gnu.org/onlinedocs/gcc-7.3.0/gcc/Diagnostic-Message-Formatting-Options.html)) |
 | [Git](https://git-scm.com/) | `git config --global color.ui false` ([Docs](https://git-scm.com/docs/git-config#git-config-colorui))|
+| [GitHub](https://git-scm.com/) | `gh config set prompt disabled` ([Docs](https://cli.github.com/manual/gh_config))|
 | [GoAccess](https://goaccess.io/) | `goaccess --no-color` ([Docs](https://goaccess.io/man#options)) |
 | [GStreamer](https://gstreamer.freedesktop.org/) | `export GST_DEBUG_NO_COLOR=true` or `--gst-debug-no-color` ([Docs](https://gstreamer.freedesktop.org/documentation/gstreamer/running.html)) |
 | [Lynx](http://lynx.browser.org/) | `lynx -nocolor` (or `show_color=never` in `.lynxrc`) |


### PR DESCRIPTION
gh does respect NO_COLOR to a degree, but still outputs escapes on command prompts. See https://github.com/cli/cli/issues/6391#issuecomment-1268220835.