### PR TITLE
Move Clang to the “supporting” list

### DIFF
--- a/index.md
+++ b/index.md
@@ -158,6 +158,7 @@ color by default via `NO_COLOR`.
 | [cdist](https://www.cdi.st/) | Usable configuration management | [2020-06-17 / 6.6.0](https://code.ungleich.ch/ungleich-public/cdist/-/releases/6.6.0) |
 | [checkit](https://gitgud.io/BoraxMan/checkit) | File integrity tool for Linux and Unix systems. | [2022-09-08 / 0.5.1](https://gitgud.io/BoraxMan/checkit/-/tags/v0.5.1) |
 | [chezmoi](https://chezmoi.io/) | Manage dotfiles across multiple machines, securely | [2020-05-06 / 1.8.1](https://github.com/twpayne/chezmoi/releases/tag/v1.8.1) |
+| [Clang](https://clang.llvm.org/) | C compiler | [2023-09-19 / 17.0.1](https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.1) |
 | [CliFM](https://github.com/leo-arch/clifm) | The command line file manager | [2021-14-12 / 1.7](https://github.com/leo-arch/clifm/commit/c9e0a1384c8f410922731341a3e8ebfe8b98ec27) |
 | [Clipboard](https://github.com/Slackadays/Clipboard) | The cut, copy, and paste system for the terminal | [2022-12-04 / 0.1.2](https://github.com/Slackadays/Clipboard/commit/79db7ced8fc6c56f79db6555775a470d0e30616e) |
 | [Cras](https://sr.ht/~arivigo/cras/) | Cras: The Anti-Procrastination Tool | [2020-06-05 / 0.1.0](https://git.sr.ht/~arivigo/cras/refs/1.0.1) |
@@ -287,7 +288,6 @@ color by default via `NO_COLOR`.
 | [Arcanist](https://github.com/phacility/arcanist) | `arc --no-ansi COMMAND` ([Docs](http://manpages.ubuntu.com/manpages/xenial/man1/arc.1.html)) |
 | [Bundler](https://bundler.io/) | `bundle COMMAND --no-color` ([Docs](https://bundler.io/v1.15/man/bundle.1.html)) |
 | [Chalk](https://github.com/chalk/chalk) | `export FORCE_COLOR=0` ([Docs](https://github.com/chalk/chalk#supportscolor)) |
-| [Clang](https://clang.llvm.org/) | `-fno-color-diagnostics` ([Docs](https://clang.llvm.org/docs/UsersManual.html#formatting-of-diagnostics)) |
 | [CMake](https://cmake.org/) | Set `CMAKE_COLOR_MAKEFILE` to `OFF` ([Docs](https://cmake.org/cmake/help/latest/variable/CMAKE_COLOR_MAKEFILE.html)) |
 | [Cocoapods](https://cocoapods.org/) | `pod COMMAND --no-ansi` ([Docs](https://guides.cocoapods.org/terminal/commands.html#pod_install)) |
 | [Composer](https://getcomposer.org/) | `composer --no-ansi` ([Docs](https://getcomposer.org/doc/03-cli.md#global-options)) |


### PR DESCRIPTION
Clang has [added support for `NO_COLOR`](https://github.com/llvm/llvm-project/commit/da0a7d5cfb0c65bcb54a1ba5ed6c93bb906648e4), which should be released in 17.0.0. I’m not familiar with LLVM’s release process, but I think Clang 17.0.0 should be out in two weeks or so? I’ll update this PR when that happens.