### PR TITLE
Add dark-mode support and improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ repository and update `index.md` with a line under the appropriate section,
 keeping entries in alphabetical order.
 The line must be formatted as:
 
-     | [Software Name](URL) | Short description | [YYYY-MM-DD / X.X.X](URL) |
+``` markdown
+| [Software Name](URL) | Short description | [YYYY-MM-DD / X.X.X](URL) |
+```
 
 For the third field, the date and version number should be those of the first
 release of the software available with `NO_COLOR` support, with a link to the
@@ -34,8 +36,10 @@ rebuilt within a few minutes.
 If you are making extensive changes to the output and want to verify them in a
 browser before committing, you can setup a Jekyll environment with:
 
-	no_color$ bundle install
-	no_color$ bundle exec jekyll serve
+``` console
+$ bundle install
+$ bundle exec jekyll serve
+```
 
 And then visit
 [http://127.0.0.1:4000/](http://127.0.0.1:4000/).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,15 +1,31 @@
 <!doctype html>
-<html lang="en">
+<html lang="en-US">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>NO_COLOR: disabling ANSI color output by default</title>
 	<style>
+		* {
+			box-sizing: border-box;
+			tab-size: 4;
+		}
+		html {
+			font: 11pt/1.33 sans-serif;
+		}
 		body {
-			font-family: sans-serif;
-			font-size: 11pt;
+			margin: 1em;
 		}
 
+		/* Links */
+		a:link, a:visited {
+			color: #0969da;
+			text-decoration: none;
+		}
+		a:hover {
+			text-decoration: underline;
+		}
+
+		/* Headings */
 		h1 {
 			font-size: 20pt;
 			margin: 0;
@@ -28,22 +44,27 @@
 			font-weight: normal;
 		}
 
+		/* Centred column */
 		#wrapper {
-			margin: 3em auto;
-			width: 800px;
+			margin: 1em auto;
+			max-width: 800px;
+		}
+		#wrapper > h1:first-of-type {
+			margin-top: 0;
 		}
 
+		/* Tables */
 		table {
 			width: 100%;
-		}
-
-		th {
-			background-color: #ddd;
 		}
 
 		th, td {
 			padding: 0.25em;
 			vertical-align: top;
+		}
+		th {
+			background-color: #ddd;
+			border-bottom-style: solid;
 		}
 
 		table tr td:first-child {
@@ -65,15 +86,45 @@
 			padding: 3px;
 		}
 
+		/* Insets */
 		blockquote, pre {
 			margin-left: 3em;
 			overflow: auto;
 		}
 
-		@media only screen and (max-width: 800px) {
-			#wrapper {
-				margin: 1em;
-				width: auto;
+		blockquote > p {
+			margin: 0;
+		}
+
+		blockquote > p:not(:last-child) {
+			margin-bottom: 1em;
+		}
+
+		/* Smartphone-size viewports */
+		@media (max-width: 600px) {
+			ol, ul {
+				padding-left: 1em;
+			}
+			blockquote, pre {
+				margin-left: 1.5em;
+			}
+		}
+
+		/* Dark mode */
+		@media (prefers-color-scheme: dark) {
+			:root {
+				background-color: #0d1117;
+				color: #e6edf3;
+			}
+			a:link, a:visited {
+				color: #2f81f7;
+			}
+			th {
+				background-color: #161b22;
+				border-color: #30363d;
+			}
+			td code, p code {
+				background-color: rgba(110, 118, 129, 0.3);
 			}
 		}
 	</style>

--- a/index.md
+++ b/index.md
@@ -35,22 +35,24 @@ with this standard.
 
 ## Example Implementation
 
-	#include <stdbool.h>
-	#include <stdio.h>
-	#include <stdlib.h>
+``` c
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-	int
-	main(int argc, char *argv[])
-	{
-		char *no_color = getenv("NO_COLOR");
-		bool color = true;
+int
+main(int argc, char *argv[])
+{
+	char *no_color = getenv("NO_COLOR");
+	bool color = true;
 
-		if (no_color != NULL && no_color[0] != '\0')
-			color = false;
+	if (no_color != NULL && no_color[0] != '\0')
+		color = false;
 
-		/* do getopt(3) and/or config-file parsing to possibly turn color back on */
-		...
-	}
+	/* do getopt(3) and/or config-file parsing to possibly turn color back on */
+	...
+}
+```
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
This commit adds dark-mode support to `no-color.org` and makes several tweaks to the existing styling to improve readability:

<details open><summary><b>Before and after refactoring</b></summary><img src="https://github.com/jcs/no_color/assets/2346707/20f9feb5-2c94-4247-8ca3-963b81463e83" alt="Before and after refactoring" width="424"/></details>

<details open><summary><b>Dark mode previews</b></summary><table><thead><tr
	><th colspan="2" align="center">Desktop</th
></tr></thead><tbody><tr
	><td><img src="https://github.com/jcs/no_color/assets/2346707/a6d55214-5573-4f4d-a607-83eb372bf5ce"  width="374" alt="Desktop view, dark-mode"/></td
	><td><img src="https://github.com/jcs/no_color/assets/2346707/037958e2-cdc7-4b18-a1ca-1bd7665ff80f" width="374" alt="Desktop view, light-mode"/></td
></tr></tbody></table>

<table><thead><tr
	><th colspan="2" align="center">Mobile</th
></tr></thead><tbody><tr
	><td><img src="https://github.com/jcs/no_color/assets/2346707/9b7d5dd2-b3a5-46be-ba4b-f5b049d77ecd"  width="374" alt="Mobile view, dark-mode"/></td
	><td><img src="https://github.com/jcs/no_color/assets/2346707/760f467d-094e-4c7a-a1ce-f713e11c10a3" width="374" alt="Mobile view, light-mode"/></td
></tr></tbody></table></details>