### PR TITLE
Adding Terraform `-no-color` option

### DIFF
--- a/index.md
+++ b/index.md
@@ -310,6 +310,7 @@ color by default via `NO_COLOR`.
 | [Radare](https://www.radare.org/r/) | `radare2 -e scr.color=0` |
 | [RSpec](http://rspec.info/) | `export SPEC_OPTS=--no-color` |
 | [Ruby (tests)](https://www.ruby-lang.org/) | `export RUBY_TESTOPTS=--color=never` |
+| [Terraform](https://www.terraform.io/) | `terraform [main command] -no-color` ([Docs](https://developer.hashicorp.com/terraform/cli/commands/plan#no-color) \| [Open Issue](https://github.com/hashicorp/terraform/issues/23708)) |
 | [The Silver Searcher](https://geoff.greer.fm/ag/) | `ag --nocolor` ([Rejected `NO_COLOR` Request](https://github.com/ggreer/the_silver_searcher/pull/1207)) |
 | [Thor](http://whatisthor.com/) | `export THOR_SHELL=Basic` ([Docs](http://www.rubydoc.info/github/wycats/thor/Thor%2FBase.shell)) |
 | [util-linux](https://github.com/karelzak/util-linux) | `touch /etc/terminal-colors.d/disable` ([Docs](http://man7.org/linux/man-pages/man5/terminal-colors.d.5.html)) |


### PR DESCRIPTION
`terraform` does not yet support `NO_COLOR`, but most commands support a `-no-color` option.

There is an open discussion at https://github.com/hashicorp/terraform/issues/23708 to implement `NO_COLOR`, but it appears the issue could use some help with clarifying some things.