### PR TITLE
Add zellij

### DIFF
--- a/index.md
+++ b/index.md
@@ -325,4 +325,5 @@ color by default via `NO_COLOR`.
 | [Thor](http://whatisthor.com/) | `export THOR_SHELL=Basic` ([Docs](http://www.rubydoc.info/github/wycats/thor/Thor%2FBase.shell)) |
 | [util-linux](https://github.com/karelzak/util-linux) | `touch /etc/terminal-colors.d/disable` ([Docs](http://man7.org/linux/man-pages/man5/terminal-colors.d.5.html)) |
 | [Vim](http://www.vim.org/) | `vim '+set t_Co=0'` |
+| [zellij](https://zellij.dev/) | `zellij --no-formatting` ([GitHub Issue #3057](https://github.com/zellij-org/zellij/issues/3057)) |
 {: rules="groups"}


### PR DESCRIPTION
zellijz doesn't support `NO_COLOR` (yet), but there's a GitHub issue at https://github.com/zellij-org/zellij/issues/3057 which also provides the hint to use the `--no-formatting` arg.