### PR TITLE
docs: add tree-sitter to software supporting NO_COLOR list

### DIFF
--- a/index.md
+++ b/index.md
@@ -282,6 +282,7 @@ color by default via `NO_COLOR`.
 | [Telescope](https://telescope.omarpolo.com) | Gemini browser | [2021-06-27 / 0.3](https://github.com/omar-polo/telescope/releases/tag/0.3) |
 | [tio](https://github.com/tio/tio) | A simple serial device I/O tool | [2024-03-06](https://github.com/tio/tio/commit/ed4ac0c797cd25b0b5d31a7654349e928b3eac58) |
 | [tree](https://oldmanprogrammer.net/source.php?dir=projects/tree) | Recursive directory listing command | [2022-12-26 / 2.1.0](https://gitlab.com/OldManProgrammer/unix-tree/-/blob/22a2e268206b8d2238a686458c4702f9b3689e5b/CHANGES) |
+| [Tree-Sitter](https://tree-sitter.github.io) | A parser generator tool and an incremental parsing library | [2024-05-05 / 0.22.6](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.22.6) |
 | [TreeViewer](https://treeviewer.org) | Phylogenetic tree visualisation software | [2021-02-19 / 1.0.0](https://github.com/arklumpus/TreeViewer/releases/tag/v1.0.0) |
 | [Trunk Recorder](https://trunkrecorder.com) | Radio recorder for P25, SmartNet, and conventional systems | [2023-12-02 / 4.7.0](https://github.com/robotastic/trunk-recorder/releases/tag/v4.7.0) |
 | [tsfm](https://npmjs.com/package/tsfm) | Light TUI file manager | [2023-07-19 / 2.4.0](https://github.com/akpi816218/tsfm/releases/tag/v2.4.0) |


### PR DESCRIPTION
Tree-Sitter has added support for no color ever since May 5, 2024 in [v0.22.6](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.22.6) :grin: 