### PR TITLE
Add bibtex autocomplete

### DIFF
--- a/index.md
+++ b/index.md
@@ -159,6 +159,7 @@ color by default via `NO_COLOR`.
 | [bat](https://github.com/sharkdp/bat) | cat(1) clone with syntax highlighting and Git integration | [2020-10-02 / 0.16.0](https://github.com/sharkdp/bat/releases/tag/v0.16.0) |
 | [beets](https://github.com/beetbox/beets) | Music library manager and MusicBrainz tagger | [2019-05-30 / 1.4.9](https://github.com/beetbox/beets/releases/tag/v1.4.9) |
 | [bfs](https://github.com/tavianator/bfs) | Breadth-first version of the UNIX find command | [2019-05-06 / 1.4.1](https://github.com/tavianator/bfs/releases/tag/1.4.1) |
+| [Bibtex autocomplete](https://github.com/dlesbre/bibtex-autocomplete) | Autocomplete bibtex files by querying online databases | [2025-03-03 / 1.4.1](https://github.com/dlesbre/bibtex-autocomplete/releases/tag/v1.4.1) |
 | [Bikeshed](https://github.com/tabatkins/bikeshed) | Spec/Document Processor | [2018-07-27 / 0.9](https://github.com/tabatkins/bikeshed/commit/04ea123d607a8d4bed692ad73dda1cb343bb5bbe) |
 | [Bloop](https://github.com/scalacenter/bloop) | Compilation/test server for Scala and Java | [2018-07-02 / 1.5.3](https://github.com/scalacenter/bloop/pull/555/commits/ff6f17a0155633f86440e10d7889f077e7fbc91c) |
 | [borgmatic](https://torsion.org/borgmatic) | Simple, configuration-driven backup software | [2024-03-04 / 1.8.9](https://projects.torsion.org/borgmatic-collective/borgmatic/commit/16bc0de3fb76f027c81353899d4e7a4d6b386dbc) |

--- a/index.md
+++ b/index.md
@@ -159,7 +159,7 @@ color by default via `NO_COLOR`.
 | [bat](https://github.com/sharkdp/bat) | cat(1) clone with syntax highlighting and Git integration | [2020-10-02 / 0.16.0](https://github.com/sharkdp/bat/releases/tag/v0.16.0) |
 | [beets](https://github.com/beetbox/beets) | Music library manager and MusicBrainz tagger | [2019-05-30 / 1.4.9](https://github.com/beetbox/beets/releases/tag/v1.4.9) |
 | [bfs](https://github.com/tavianator/bfs) | Breadth-first version of the UNIX find command | [2019-05-06 / 1.4.1](https://github.com/tavianator/bfs/releases/tag/1.4.1) |
-| [Bibtex autocomplete](https://github.com/dlesbre/bibtex-autocomplete) | Autocomplete bibtex files by querying online databases | [2025-03-03 / 1.4.1](https://github.com/dlesbre/bibtex-autocomplete/releases/tag/v1.4.1) |
+| [Bibtex autocomplete](https://github.com/dlesbre/bibtex-autocomplete) | Autocomplete bibtex entries using online data | [2025-03-03 / 1.4.1](https://github.com/dlesbre/bibtex-autocomplete/releases/tag/v1.4.1) |
 | [Bikeshed](https://github.com/tabatkins/bikeshed) | Spec/Document Processor | [2018-07-27 / 0.9](https://github.com/tabatkins/bikeshed/commit/04ea123d607a8d4bed692ad73dda1cb343bb5bbe) |
 | [Bloop](https://github.com/scalacenter/bloop) | Compilation/test server for Scala and Java | [2018-07-02 / 1.5.3](https://github.com/scalacenter/bloop/pull/555/commits/ff6f17a0155633f86440e10d7889f077e7fbc91c) |
 | [borgmatic](https://torsion.org/borgmatic) | Simple, configuration-driven backup software | [2024-03-04 / 1.8.9](https://projects.torsion.org/borgmatic-collective/borgmatic/commit/16bc0de3fb76f027c81353899d4e7a4d6b386dbc) |


### PR DESCRIPTION
Adds [bibtex autocomplete](https://github.com/dlesbre/bibtex-autocomplete) to the list, as I've just released a new version with `NO_COLOR` support.