### PR TITLE
Add Gradle

### DIFF
--- a/index.md
+++ b/index.md
@@ -247,6 +247,7 @@ color by default via `NO_COLOR`.
 | [gopass](https://github.com/gopasspw/gopass) | Password store for teams | [2018-06-06 / 1.8.0](https://github.com/gopasspw/gopass/releases/tag/v1.8.0) |
 | [gplaces](https://github.com/dimkr/gplaces) | Simple terminal based Gemini client | [2022-06-05 / 0.16.19](https://github.com/dimkr/gplaces/commit/c907bdf719ad069da2f75daf01f371921f5fde0f) |
 | [GraalVM Native Image](https://www.graalvm.org/native-image/) | Compile Java applications ahead-of-time into binaries | [2022-02-28 / 22.1.0](https://github.com/oracle/graal/commit/20f912e13cd97c3c3b527522b194a61eac71a93b) |
+| [Gradle](https://gradle.org/) | Build tool for JVM and polyglot projects | [2026-05-28 / 9.6.0-rc-1](https://docs.gradle.org/9.6.0-rc-1/release-notes.html) |
 | [gwen](https://github.com/gwen-interpreter/gwen) | Automation and robotics for Gherkin | [2021-11-16 / 3.0.0](https://github.com/gwen-interpreter/gwen/releases/tag/v3.0.0) |
 | [h5glance](https://github.com/European-XFEL/h5glance) | HDF5 file viewer | [2024-11-19 / 0.9](https://github.com/European-XFEL/h5glance/blob/master/CHANGES.rst) |
 | [Hajime](https://github.com/Slackadays/Hajime) | Advanced Minecraft server wrapper | [2022-02-27](https://github.com/Slackadays/Hajime/commit/7ff89c1d29d901ab0dc47474ee85619fbfbbd226) |


### PR DESCRIPTION
Gradle 9.6.0 RC1 adds `NO_COLOR` support.

* [Release Notes](https://docs.gradle.org/9.6.0-rc-1/release-notes.html#no-color-support)
* [Manual](https://docs.gradle.org/9.6.0-rc-1/userguide/build_environment.html#environment_variables_reference)
* https://github.com/gradle/gradle/pull/37429
